### PR TITLE
Support `no_std`

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -17,3 +17,8 @@ cargo test
 cargo test --release
 
 cargo run --release --example dump_phdrs
+
+# Test no_std
+cargo test --no-default-features --features=alloc
+cargo test --no-default-features --features=alloc --release
+cargo run --no-default-features --features=alloc --release --example dump_phdrs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,11 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = { version = "0.2.94", default-features = false }
+core = { version = "1.0.0", optional = true, package = 'rustc-std-workspace-core' }
+compiler_builtins = { version = "0.1.16", optional = true }
 
 [features]
 default = ["std"]
+rustc-dep-of-std = ['core', 'compiler_builtins']
 std = []
 alloc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,9 @@ edition = "2018"
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-libc = "0.2.94"
+libc = { version = "0.2.94", default-features = false }
+
+[features]
+default = ["std"]
+std = []
+alloc = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,3 @@ license = "Apache-2.0 OR MIT"
 
 [dependencies]
 libc = "0.2.94"
-elf = "0.0.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-pub use elf::types::{PF_R, PF_W, PF_X};
 use libc::{c_int, dl_iterate_phdr, dl_phdr_info};
 pub use libc::{
     PF_MASKPROC, PT_DYNAMIC, PT_GNU_EH_FRAME, PT_GNU_RELRO, PT_HIOS, PT_HIPROC, PT_INTERP, PT_LOAD,
@@ -22,6 +21,13 @@ use libc::{
     Elf32_Addr as Elf_Addr, Elf32_Half as Elf_Half, Elf32_Off as Elf_Off, Elf32_Phdr as Elf_Phdr,
     Elf32_Word as Elf_Word, Elf32_Xword as Elf_Xword,
 };
+
+/// Executable program segment
+const PF_X: u32 = 1;
+/// Writable program segment
+const PF_W: u32 = 2;
+/// Readable program segment
+const PF_R: u32 = 4;
 
 /// Contains information about an "object" in the virtual address space.
 /// This corresponds with a `dl_phdr_info` in C. Note that the contents of the C struct differ
@@ -154,13 +160,13 @@ impl Debug for ProgramHeader {
 
         let flags = self.flags();
         let mut flag_strs = Vec::new();
-        if flags & PF_X.0 != 0 {
+        if flags & PF_X != 0 {
             flag_strs.push("PF_X");
         }
-        if flags & PF_W.0 != 0 {
+        if flags & PF_W != 0 {
             flag_strs.push("PF_W");
         }
-        if flags & PF_R.0 != 0 {
+        if flags & PF_R != 0 {
             flag_strs.push("PF_R");
         }
         if flags & PF_MASKPROC != 0 {


### PR DESCRIPTION
The motivation for this is that I end up using `phdrs` in Alloy for compiler generated TLS support and this means that it must support being built without a standard library.