### PR TITLE
Allow rustc to automatically link to alloc

### DIFF
--- a/.buildbot.sh
+++ b/.buildbot.sh
@@ -19,6 +19,6 @@ cargo test --release
 cargo run --release --example dump_phdrs
 
 # Test no_std
-cargo test --no-default-features --features=alloc
-cargo test --no-default-features --features=alloc --release
-cargo run --no-default-features --features=alloc --release --example dump_phdrs
+cargo test --no-default-features
+cargo test --no-default-features --release
+cargo run --no-default-features --release --example dump_phdrs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ license = "Apache-2.0 OR MIT"
 libc = { version = "0.2.94", default-features = false }
 core = { version = "1.0.0", optional = true, package = 'rustc-std-workspace-core' }
 compiler_builtins = { version = "0.1.16", optional = true }
+alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-alloc" }
 
 [features]
 default = ["std"]
-rustc-dep-of-std = ['core', 'compiler_builtins']
+rustc-dep-of-std = ['core', 'compiler_builtins', 'alloc']
 std = []
-alloc = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg(not(feature = "rustc-dep-of-std"))]
+extern crate alloc;
 
 use libc::{c_int, c_void, dl_iterate_phdr, dl_phdr_info};
 pub use libc::{
@@ -12,12 +14,10 @@ use core::{
     iter::Iterator,
 };
 
-#[cfg(feature = "alloc")]
-extern crate alloc;
-#[cfg(feature = "alloc")]
+#[cfg(not(feature = "std"))]
 use alloc::{borrow::ToOwned, ffi::CString, format, string::String, vec::Vec};
 
-#[cfg(not(feature = "alloc"))]
+#[cfg(feature = "std")]
 use std::ffi::CString;
 
 #[cfg(target_pointer_width = "64")]
@@ -89,7 +89,7 @@ impl Object {
 }
 
 impl Debug for Object {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "Object {{ addr: 0x{:x}, name: {:?}, phdrs: {:?}, num_phdrs: {} }}",
@@ -145,7 +145,7 @@ impl ProgramHeader {
 }
 
 impl Debug for ProgramHeader {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut to_write = String::from("ProgramHeader(");
         let type_ = self.type_();
         let type_str = match type_ {


### PR DESCRIPTION
This hack is necessary for rustc point to the correct version of the alloc crate when `phdrs` is used in `library/std` during the bootstrap process.