### PR TITLE
`dlpi_tls_data` doesn't exist on all platforms.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub struct Object {
     phdrs: *const Elf_Phdr,
     /// The number of program headers.
     num_phdrs: Elf_Half,
+    #[cfg(target_os = "linux")]
     /// The current threads TLS data.
     tls_data: *const c_void,
 }
@@ -83,6 +84,7 @@ impl Object {
     /// Returns a pointer to the current thread's TLS data. This will point to
     /// an address inside the TLS segment at some fixed offset calculated from
     /// the current thread.
+    #[cfg(target_os = "linux")]
     pub fn tls_data(&self) -> *const c_void {
         self.tls_data
     }
@@ -231,6 +233,7 @@ pub fn objects() -> Vec<Object> {
             name,
             phdrs: obj.dlpi_phdr,
             num_phdrs: obj.dlpi_phnum,
+            #[cfg(target_os = "linux")]
             tls_data: obj.dlpi_tls_data,
         });
     }


### PR DESCRIPTION
At least not on OpenBSD. For now, assume a whitelist "only expose it if we're sure" stance.